### PR TITLE
Fix column reference at callback with a function

### DIFF
--- a/AngularJS-WebApi-EF/Scripts/App/Directives/crud-grid-directive.js
+++ b/AngularJS-WebApi-EF/Scripts/App/Directives/crud-grid-directive.js
@@ -19,13 +19,18 @@
 
                 $scope.setLookupData = function () {
                     for (var i = 0; i < $scope.columns.length; i++) {
-                        var c = $scope.columns[i];
-                        if (c.lookup && !$scope.hasLookupData(c.lookup.table)) {
-                            crudGridDataFactory(c.lookup.table).query(function (data) {
-                                $scope.setIndividualLookupData(c.lookup.table, data);
-                            });
-                        }
+                        (function(i)
+                        {
+                            var c = $scope.columns[i];
+                            if (c.lookup && !$scope.hasLookupData(c.lookup.table)) {
+                                crudGridDataFactory(c.lookup.table).query(function(data) {
+                                    $scope.setIndividualLookupData(c.lookup.table, data);
+                                });
+                            }
+                        })(i)
+                        ;
                     }
+
                 };
 
                 $scope.resetLookupData = function(table) {


### PR DESCRIPTION
If you have more than one lookup column in your row, the data won't show.
The reference to the column c isn't correctly at the (asynchronous) callback call.

(btw: thanks for your great CRUD Grid! :-))
